### PR TITLE
Create options for the transport, add HeartbeatTimeout option

### DIFF
--- a/options.go
+++ b/options.go
@@ -1,0 +1,13 @@
+package transport
+
+import "time"
+
+type Option func(m *Manager)
+
+// WithHeartbeatTimeout configures the transport to not wait for than d for
+// heartbeat to be executes by remote peer.
+func WithHeartbeatTimeout(d time.Duration) Option {
+	return func(m *Manager) {
+		m.heartbeatTimeout = d
+	}
+}

--- a/raftapi.go
+++ b/raftapi.go
@@ -63,7 +63,13 @@ func (r raftAPI) AppendEntries(id raft.ServerID, target raft.ServerAddress, args
 	if err != nil {
 		return err
 	}
-	ret, err := c.AppendEntries(context.TODO(), encodeAppendEntriesRequest(args))
+	ctx := context.TODO()
+	if r.manager.heartbeatTimeout > 0 && isHeartbeat(args) {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, r.manager.heartbeatTimeout)
+		defer cancel()
+	}
+	ret, err := c.AppendEntries(ctx, encodeAppendEntriesRequest(args))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
By default, gRPC will retry and wait for RPC calls. It's undesirable for heartbeats.