### PR TITLE
Fix issue with stale clientConn

### DIFF
--- a/raftapi.go
+++ b/raftapi.go
@@ -46,6 +46,15 @@ func (r raftAPI) getPeer(id raft.ServerID, target raft.ServerAddress) (pb.RaftTr
 		c.mtx.Lock()
 	}
 	defer c.mtx.Unlock()
+
+	if c.clientConn != nil && c.clientConn.Target() != string(target) {
+		err := c.clientConn.Close()
+		if err != nil {
+			return nil, err
+		}
+		c.clientConn = nil
+	}
+
 	if c.clientConn == nil {
 		conn, err := grpc.Dial(string(target), r.manager.dialOptions...)
 		if err != nil {


### PR DESCRIPTION
The Transport does not check if the IP address of a node has changed and returns the connection created with outdated info. 
This happens in environments with dynamic IPs such a docker and Kubernetes.
This fix adds an additional check to ensure that the target IP is up to date.